### PR TITLE
Cover letters: hand-logged jobs write from the same JD cascade as tailoring

### DIFF
--- a/backend/api/routes_applications.py
+++ b/backend/api/routes_applications.py
@@ -243,6 +243,19 @@ async def _cache_job_page(job_id: str, url: str):
         _set_job_cache_error(job_id, msg)
 
 
+async def _fetch_and_store_description(job_id: str, url: str) -> None:
+    """Write the ATS-quality JD onto a job that has none. `_resolve_tailoring_jd`
+    owns the fetch, the SSRF gate and the write, so this adds no second cascade."""
+    from types import SimpleNamespace
+    from backend.api.routes_resumes import _resolve_tailoring_jd
+    try:
+        await _resolve_tailoring_jd(
+            SimpleNamespace(id=job_id, description="", url=url, cached_page_text="")
+        )
+    except Exception as e:
+        logger.warning(f"Could not fetch a description for job {job_id}: {e}")
+
+
 @router.post("")
 def create_application(
     data: ApplicationCreate,
@@ -327,6 +340,12 @@ def create_application(
 
     if data.url and not job.has_cached_page:
         background_tasks.add_task(_cache_job_page, str(job.id), data.url)
+
+    # A hand-logged job arrives with no description, which every LLM step needs.
+    # Fetch it once here instead of on first use, so the first score, tailor or
+    # cover letter does not pay for it.
+    if data.url and not (job.description or "").strip():
+        background_tasks.add_task(_fetch_and_store_description, str(job.id), data.url)
 
     return {
         "id": str(app.id),

--- a/backend/api/routes_cover_letters.py
+++ b/backend/api/routes_cover_letters.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from backend.models.db import get_db, CoverLetter, Resume, Job, Setting, Persona, TracerLink, TracerClickEvent, SessionLocal
 from backend.api._input import str_field, uuid_filter
 from backend.job_monitor import launch_background, JobAlreadyRunningError
-from backend.api.routes_resumes import _get_browser, _rewrite_urls_with_tracers  # shared with resumes
+from backend.api.routes_resumes import _get_browser, _rewrite_urls_with_tracers, _resolve_tailoring_jd  # shared with resumes
 
 logger = logging.getLogger("jobnavigator.cover_letters")
 
@@ -338,8 +338,11 @@ async def generate_cover_letter(body: dict, db: Session = Depends(get_db)):
     job = db.query(Job).filter(Job.id == job_id).first()
     if not job:
         raise HTTPException(404, "Job not found")
-    if not (job.description or "").strip():
-        raise HTTPException(400, "Job has no description")
+    # Fast-fail: the job needs some JD source; _generate_inner resolves the actual
+    # text (description -> live fetch -> cached page) later, so this skips the slow fetch.
+    # A hand-logged job (Log application) arrives with a URL and no description.
+    if not ((job.description or "").strip() or (job.url or "").strip() or (job.cached_page_text or "").strip()):
+        raise HTTPException(400, "Job has no description, URL, or cached page to write from")
 
     prompt_row = db.query(Setting).filter(Setting.key == "cover_letter_prompt").first()
     if not prompt_row or not (prompt_row.value or "").strip():
@@ -392,6 +395,8 @@ async def _generate_inner(resume_id, job_id, voice, length, template, page_forma
                           cover_letter_id=None):
     """Read -> LLM -> write, each with its own short session, so no pooled
     connection is held while the generation call is awaited."""
+    from types import SimpleNamespace
+
     # -- Phase 1: read the evidence and the prompt, then release -------------
     db = SessionLocal()
     try:
@@ -402,7 +407,10 @@ async def _generate_inner(resume_id, job_id, voice, length, template, page_forma
 
         job_company = job.company
         job_title = job.title
-        job_description = job.description or ""
+        # Detached snapshot: phase 1b resolves the JD after this session closes,
+        # so no pooled connection is held across a live page fetch.
+        job_ref = SimpleNamespace(id=job.id, description=job.description,
+                                  url=job.url, cached_page_text=job.cached_page_text)
 
         # Resolve the evidence source: Persona.resume_content or a Resume row.
         persona_as_base = (resume_id == "persona")
@@ -433,6 +441,11 @@ async def _generate_inner(resume_id, job_id, voice, length, template, page_forma
         _provider, _model = _cfg["provider"], _cfg["model"]
     finally:
         db.close()
+
+    # -- Phase 1b: resolve the JD (may fetch the page), no session held ------
+    job_description = await _resolve_tailoring_jd(job_ref)
+    if not job_description:
+        raise RuntimeError(f"cover letter: job {job_id} has no usable description")
 
     # -- Phase 2: the LLM call, with no connection held ----------------------
     async with track_llm_call("cover_letter", _provider, _model, job_id=job_id) as _tracker:

--- a/backend/main.py
+++ b/backend/main.py
@@ -671,7 +671,7 @@ async def trigger_auto_reject():
 
 @app.post("/api/jobs/backfill-descriptions", tags=["triggers"], summary="Fetch descriptions for jobs missing them", status_code=202)
 async def trigger_backfill_descriptions():
-    """Fetch job descriptions for saved/new jobs that have a URL but no description."""
+    """Fetch job descriptions for new/saved/applied jobs that have a URL but no description."""
     async def _do():
         from backend.models.db import Job
         from backend.scraper.ats._descriptions import _fetch_job_description
@@ -679,7 +679,9 @@ async def trigger_backfill_descriptions():
         db = SessionLocal()
         try:
             jobs = db.query(Job).filter(
-                Job.status.in_(["new", "saved"]),
+                # "applied" is in the set because a hand-logged job (Log application)
+                # lands there directly and needs the same repair.
+                Job.status.in_(["new", "saved", "applied"]),
                 Job.url != None,
                 (Job.description == None) | (Job.description == ""),
             ).order_by(Job.discovered_at.desc()).limit(50).all()

--- a/backend/tests/r4_support.py
+++ b/backend/tests/r4_support.py
@@ -95,6 +95,7 @@ def _no_outbound(monkeypatch):
     import backend.analyzer.h1b_checker as h1b
 
     monkeypatch.setattr(ra, "_cache_job_page", _noop, raising=False)
+    monkeypatch.setattr(ra, "_fetch_and_store_description", _noop, raising=False)
     monkeypatch.setattr(rc, "_fire_h1b_async", _noop, raising=False)
     monkeypatch.setattr(h1b, "fetch_h1b_for_company_id", _noop, raising=False)
     monkeypatch.setattr(h1b, "refresh_all_h1b", _noop, raising=False)

--- a/backend/tests/test_backfill_descriptions_scope.py
+++ b/backend/tests/test_backfill_descriptions_scope.py
@@ -1,0 +1,52 @@
+"""The description backfill must reach hand-logged jobs too: they land at
+`applied` straight away, so a `new`/`saved` filter never repairs them."""
+import uuid
+
+import pytest
+
+from backend.models.db import Job
+
+
+def _job(db, status, description=""):
+    j = Job(id=uuid.uuid4(), external_id=uuid.uuid4().hex, company="Acme",
+            title=f"PM {status}", url=f"https://acme.com/{status}", status=status,
+            description=description)
+    db.add(j)
+    db.commit()
+    return j
+
+
+@pytest.mark.asyncio
+async def test_backfill_covers_applied_jobs(test_db, monkeypatch):
+    import backend.main as main
+    captured = {}
+
+    def _capture(job_type, coro_func, **kw):
+        captured["func"] = coro_func
+        return "run-1"
+
+    monkeypatch.setattr(main, "launch_background", _capture)
+
+    applied = _job(test_db, "applied")
+    saved = _job(test_db, "saved")
+    rejected = _job(test_db, "rejected")
+
+    async def fake_fetch(url):
+        # The backfill drops anything under 50 chars, so pad it.
+        return f"JD for {url} — senior product role, roadmapping, discovery."
+
+    monkeypatch.setattr("backend.scraper.ats._descriptions._fetch_job_description", fake_fetch)
+    monkeypatch.setattr("asyncio.sleep", lambda *a, **kw: _noop())
+
+    await main.trigger_backfill_descriptions()
+    await captured["func"]()
+
+    test_db.expire_all()
+    assert test_db.query(Job).filter(Job.id == applied.id).first().description .startswith("JD for https://acme.com/applied")
+    assert test_db.query(Job).filter(Job.id == saved.id).first().description .startswith("JD for https://acme.com/saved")
+    # An out-of-scope status stays untouched -- the backfill is not a free-for-all.
+    assert not (test_db.query(Job).filter(Job.id == rejected.id).first().description or "")
+
+
+async def _noop():
+    return None

--- a/backend/tests/test_r4_contract_documents.py
+++ b/backend/tests/test_r4_contract_documents.py
@@ -373,9 +373,11 @@ def test_generate_cover_letter_unknown_job_is_404(client, test_db):
         "resume_id": str(res.id), "job_id": MISSING_UUID}), 404)
 
 
-def test_generate_cover_letter_job_without_description_is_400(client, test_db):
+def test_generate_cover_letter_job_without_any_jd_source_is_400(client, test_db):
+    """A job with no description, no URL and no cached page has nothing to write from.
+    A job with a URL alone (hand-logged) is accepted -- the worker resolves the text."""
     res = make_resume(test_db)
-    job = make_job(test_db)
+    job = make_job(test_db, url="")
     assert_clean(client.post("/api/cover-letters/generate", json={
         "resume_id": str(res.id), "job_id": str(job.id)}), 400)
 

--- a/backend/tests/test_routes_applications.py
+++ b/backend/tests/test_routes_applications.py
@@ -1,6 +1,11 @@
 """Tests for /api/applications endpoints + dedup + transition + company auto-create."""
 import pytest
 
+# Bound at import time, before the autouse fixture below replaces the module attribute.
+from backend.api.routes_applications import (
+    _fetch_and_store_description as real_fetch_and_store_description,
+)
+
 
 def _seed_first_run(test_db):
     """Seed an empty dashboard_api_key row so the auth middleware allows requests (first-run mode)."""
@@ -17,6 +22,12 @@ def _stub_background_tasks(monkeypatch):
         return None
     monkeypatch.setattr(
         "backend.api.routes_applications._cache_job_page",
+        _noop_cache,
+        raising=False,
+    )
+    # _fetch_and_store_description is the second task the route schedules.
+    monkeypatch.setattr(
+        "backend.api.routes_applications._fetch_and_store_description",
         _noop_cache,
         raising=False,
     )
@@ -144,3 +155,67 @@ def test_create_application_twice_returns_409(api_client, test_db):
     mine = [a for a in apps if a.get("id") == first.json()["id"]]
     assert len(mine) == 1 and mine[0]["status"] == "applied"
     assert mine[0].get("notes", "first") == "first"
+
+
+# ── JD fetched at log time ───────────────────────────────────────────────────
+
+def test_log_schedules_a_description_fetch(api_client, test_db, monkeypatch):
+    """A hand-logged job has no description, so the route queues one fetch."""
+    import backend.api.routes_applications as ra
+    seen = []
+
+    async def _spy(job_id, url):
+        seen.append((job_id, url))
+
+    monkeypatch.setattr(ra, "_fetch_and_store_description", _spy, raising=False)
+    resp = api_client.post("/api/applications", json={
+        "url": "https://acme.com/jobs/7", "title": "Senior PM", "company": "Acme"})
+    assert resp.status_code == 200
+    assert len(seen) == 1
+    assert seen[0][1] == "https://acme.com/jobs/7"
+
+
+def test_log_skips_the_fetch_when_the_job_already_has_a_description(api_client, test_db, monkeypatch):
+    """The job row exists from a scrape and carries a JD, so nothing is fetched."""
+    import uuid
+    import backend.api.routes_applications as ra
+    from backend.models.db import Job
+    from backend.scraper._shared.dedup import make_external_id
+
+    url = "https://acme.com/jobs/8"
+    test_db.add(Job(id=uuid.uuid4(), external_id=make_external_id("Acme", "Senior PM", url),
+                    company="Acme", title="Senior PM", url=url, status="saved",
+                    description="Scraped JD"))
+    test_db.commit()
+
+    seen = []
+
+    async def _spy(job_id, url):
+        seen.append(job_id)
+
+    monkeypatch.setattr(ra, "_fetch_and_store_description", _spy, raising=False)
+    resp = api_client.post("/api/applications", json={
+        "url": url, "title": "Senior PM", "company": "Acme"})
+    assert resp.status_code == 200
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_description_writes_the_job(test_db, monkeypatch):
+    """The task delegates to the tailoring resolver, which persists the fetched text."""
+    import uuid
+    from backend.models.db import Job
+
+    job = Job(id=uuid.uuid4(), external_id=uuid.uuid4().hex, company="Acme",
+              title="Senior PM", url="https://acme.com/jobs/9", status="applied")
+    test_db.add(job)
+    test_db.commit()
+
+    async def fake_fetch(url):
+        return "Clean ATS JD for a Senior PM."
+
+    monkeypatch.setattr("backend.scraper.ats._descriptions._fetch_job_description", fake_fetch)
+    await real_fetch_and_store_description(str(job.id), job.url)
+
+    test_db.expire_all()
+    assert test_db.query(Job).filter(Job.id == job.id).first().description == "Clean ATS JD for a Senior PM."

--- a/backend/tests/test_routes_cover_letters.py
+++ b/backend/tests/test_routes_cover_letters.py
@@ -114,13 +114,31 @@ def test_generate_404_on_missing_resume(api_client, test_db):
     assert resp.status_code == 404
 
 
-def test_generate_400_on_job_without_description(api_client, test_db):
+def test_generate_400_when_no_jd_source(api_client, test_db):
+    """400 only when all three JD sources are empty: description, URL, cached page."""
     _seed_first_run(test_db)
     resume = _make_resume(test_db)
     job = _make_job(test_db, description="")
+    job.url = ""
+    test_db.commit()
     resp = api_client.post("/api/cover-letters/generate",
                            json={"resume_id": str(resume.id), "job_id": str(job.id)})
     assert resp.status_code == 400
+
+
+def test_generate_202_on_url_only_job(api_client, test_db, monkeypatch):
+    """A hand-logged job (Log application) carries a URL and no description; the
+    worker resolves the text later, so the endpoint must not refuse it."""
+    _seed_first_run(test_db)
+    resume = _make_resume(test_db)
+    job = _make_job(test_db, description="")
+
+    import backend.api.routes_cover_letters as rcl
+    monkeypatch.setattr(rcl, "launch_background", lambda *a, **kw: "run-124")
+
+    resp = api_client.post("/api/cover-letters/generate",
+                           json={"resume_id": str(resume.id), "job_id": str(job.id)})
+    assert resp.status_code == 202
 
 
 def test_generate_happy_path_returns_202(api_client, test_db, monkeypatch):
@@ -260,3 +278,41 @@ def test_base_resume_without_stub_stays_random(test_db):
     assert link is not None
     assert len(link.token) >= 8
     assert link.token != "0li"        # not the deterministic 0{stub} shape
+
+
+def test_generate_inner_resolves_jd_from_url(test_db, monkeypatch):
+    """The worker writes from a live fetch when the job has only a URL, and keeps
+    the fetched text on the job — the same order tailoring uses."""
+    import asyncio
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+    import backend.api.routes_cover_letters as rcl
+
+    _seed_first_run(test_db)
+    resume = _make_resume(test_db)
+    job = _make_job(test_db, description="")
+
+    async def fake_fetch(url):
+        return "Fetched JD: fintech PM, roadmapping."
+
+    monkeypatch.setattr("backend.scraper.ats._descriptions._fetch_job_description", fake_fetch)
+
+    seen = {}
+
+    async def fake_body(resume_data, preferences, jd, voice_instruction, length, prompt_template):
+        seen["jd"] = jd
+        return {"greeting": "Dear Acme,", "body_paragraphs": ["p"], "closing": "Regards,",
+                "signature": "Viktor"}
+
+    @asynccontextmanager
+    async def fake_track(*a, **kw):
+        yield MagicMock()
+
+    asyncio.run(rcl._generate_inner(
+        str(resume.id), str(job.id), None, "concise", None, None,
+        lambda db, voice: (None, ""), fake_body, fake_track,
+    ))
+
+    assert seen["jd"] == "Fetched JD: fintech PM, roadmapping."
+    test_db.expire_all()
+    assert test_db.query(Job).filter(Job.id == job.id).first().description == seen["jd"]


### PR DESCRIPTION
## What's broken

Add a job by hand through **Applications → + Log application** and you can't get a cover letter for it. Generation answers `400 Job has no description`.

The row really does have no description. `POST /applications` writes `Job(source="manual", status="applied")` from the URL, title and company you typed, and the background task that follows (`_cache_job_page`) fills only `cached_page_text`. Nothing ever writes `job.description` for that job.

Résumé tailoring handles the same job fine, which is what makes this odd. It reads the JD through `_resolve_tailoring_jd`: stored description first, then a live fetch that gets saved back to the job, then the cached page as a last resort. The letter path had none of that. One `if not job.description` and out.

Two smaller gaps kept the row broken:

* `create_application` never fetched a description, so the job stayed empty until some later step paid for the fetch.
* `/api/jobs/backfill-descriptions`, the one repair path there is, filtered on `status in ("new", "saved")`. A hand-logged job starts at `applied`, so the backfill never saw it.

## What changed

The letter worker calls the same `_resolve_tailoring_jd` the tailor calls, so there is one cascade now instead of two. It runs in a new phase 1b, after the read session closes, so no pooled connection is held while the page is fetched. `_tailor_impl` already splits its phases that way.

`POST /cover-letters/generate` refuses only when `description`, `url` and `cached_page_text` are all empty, which is what the tailor gate already did.

`create_application` schedules `_fetch_and_store_description` when the job has no description, so the first score, tailor or letter doesn't wait on a fetch. That task hands off to the same resolver, which owns the fetch and the write.

`/api/jobs/backfill-descriptions` covers `applied` as well.

No new endpoint, no schema change, nothing touched in the frontend.

## Tests

* `test_generate_400_when_no_jd_source` replaces the old test that asserted 400 for any job without a description. It now checks the real rule: all three sources empty.
* `test_generate_202_on_url_only_job` covers the hand-logged case.
* `test_generate_inner_resolves_jd_from_url` runs the worker and checks that the fetched text is used and saved.
* `test_log_schedules_a_description_fetch` and `test_log_skips_the_fetch_when_the_job_already_has_a_description`.
* `test_fetch_and_store_description_writes_the_job`.
* `test_backfill_covers_applied_jobs` checks that `applied` and `saved` get repaired and `rejected` is left alone.
* `test_r4_contract_documents.py` keeps the same contract under a name that says what it guards.
* `r4_support._no_outbound` and the application test fixture stub the new background task, so no test reaches the network.

Backend suite: 2266 passed, 4 skipped, 13 xfailed. Two tests in `test_r4_live_contract.py` fail (`test_negative_offset_is_clamped_not_an_error`, `test_protected_routes_require_a_key`), and they fail the same way on a clean checkout. They hit the live stack, where `dashboard_api_key` is empty.

Also ran the flow by hand against a running stack: log a posting through the modal, then generate a letter for that job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
