### PR TITLE
Add ChatGPT subscription support through Codex CLI

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -20,10 +20,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Install Playwright Chromium browser only (skip install-deps since we handled it above)
 RUN playwright install chromium
 
-# Install Node.js + Claude Code CLI (for claude -p subscription-based scoring)
+# Install subscription-backed CLIs for Claude Code and Codex providers.
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g @anthropic-ai/claude-code \
+    && npm install -g @anthropic-ai/claude-code @openai/codex@0.154.0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY backend/ ./backend/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Scrape career pages and aggregators, score jobs against your résumés with an L
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                              AI RESUME SCORING                              │
 │                                                                             │
-│   Providers ── Claude API, Claude CLI, OpenAI, OpenRouter, Ollama           │
+│   Providers ── Claude API/CLI, Codex CLI, OpenAI, OpenRouter, Ollama        │
 │   Depths ───── Light (scores only) or Full (report + keyword analysis)      │
 │   Multi ────── Score against multiple resumes, compare fit per role         │
 │                                                                             │
@@ -97,7 +97,7 @@ Scrape career pages and aggregators, score jobs against your résumés with an L
 | Feature | Description |
 |---------|-------------|
 | **Discovery** | Career pages (Playwright + 11 ATS handlers), JobSpy (LinkedIn, Indeed, ZipRecruiter, Google), LinkedIn collections, Levels.fyi, Jobright.ai, freehire.me, the Chrome extension |
-| **Scoring** | Claude, OpenAI, OpenRouter, Ollama or Claude Code; live model search, a model per feature; Light (score) or Full (report, keyword coverage, requirement mapping) against every base résumé; prompt caching on Anthropic |
+| **Scoring** | Claude, OpenAI, OpenRouter, Ollama, Claude Code or Codex CLI; live model search, a model per feature; Light (score) or Full (report, keyword coverage, requirement mapping) against every base résumé; prompt caching on Anthropic |
 | **Résumés** | Structured base résumés, tailoring per job with a review step, 8 PDF templates (drop in your own), tracked links that record opens |
 | **Cover letters** | Generated from the paired résumé and persona; voice and length presets, 8 templates, PDF |
 | **Dedup** | URL identity hash (tracking params stripped) plus company + title hash across sources |
@@ -124,6 +124,15 @@ docker compose up --build -d
 ```
 
 Open `http://localhost`. On first run sign in with a blank key, then set one in Settings › Advanced. The previous interface is at `/classic`.
+
+To use a ChatGPT subscription through Codex CLI, authenticate once after the containers start:
+
+```bash
+docker compose exec backend codex login --device-auth
+docker compose exec backend codex login status
+```
+
+The login is stored in the private `codex_auth` Docker volume and persists across container rebuilds. Select **Codex CLI (ChatGPT Subscription)** in Settings › AI; no OpenAI API key is needed for this provider.
 
 **First steps:**
 1. Settings › AI — provider and key
@@ -153,7 +162,7 @@ Install: `chrome://extensions` › Developer mode › Load unpacked › `extensi
 | Frontend | React 18, Vite, Recharts, a token-based design system ([DESIGN-SYSTEM.md](frontend/src/DESIGN-SYSTEM.md)) |
 | Database | PostgreSQL 16 |
 | Infrastructure | Docker Compose, Caddy, nginx |
-| AI | Anthropic SDK, OpenAI SDK, Ollama, Claude Code CLI |
+| AI | Anthropic SDK, OpenAI SDK, Ollama, Claude Code CLI, Codex CLI |
 | Extension | Chrome Manifest V3 |
 
 ## Contributing

--- a/backend/analyzer/llm_client.py
+++ b/backend/analyzer/llm_client.py
@@ -232,6 +232,8 @@ async def _dispatch(provider: str, model: str, api_key: str,
     combined = f"{cached_prefix}\n\n{prompt}" if cached_prefix else prompt
     if provider == "claude_code":
         return await _call_claude_code(combined, system, model, max_tokens)
+    elif provider == "codex_cli":
+        return await _call_codex_cli(combined, system, model, max_tokens)
     elif provider == "openai":
         return await _call_openai(combined, system, model, api_key, max_tokens)
     elif provider == "openrouter":
@@ -317,6 +319,60 @@ async def _call_claude_code(prompt: str, system: str, model: str, max_tokens: in
         "text": text.strip(),
         "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0, "cache_write_tokens": 0},
     }
+
+
+async def _call_codex_cli(prompt: str, system: str, model: str, max_tokens: int) -> dict:
+    """Call Codex CLI using its existing ChatGPT login; run in an empty read-only workspace."""
+    import json as _json
+    import tempfile
+
+    full_prompt = f"{system}\n\n{prompt}"
+    with tempfile.TemporaryDirectory(prefix="jobnavigator-codex-") as workdir:
+        cmd = [
+            "codex", "exec", "--ephemeral", "--ignore-user-config", "--ignore-rules",
+            "--skip-git-repo-check", "--sandbox", "read-only", "--color", "never",
+            "--json", "-C", workdir,
+        ]
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append("-")
+
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate(input=full_prompt.encode())
+
+    if process.returncode != 0:
+        error = stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"codex subprocess failed (rc={process.returncode}): {error}")
+
+    raw = stdout.decode(errors="replace").strip()
+    text = ""
+    usage = {"input_tokens": 0, "output_tokens": 0,
+             "cache_read_tokens": 0, "cache_write_tokens": 0}
+    for line in raw.splitlines():
+        try:
+            event = _json.loads(line)
+        except _json.JSONDecodeError:
+            continue
+        if event.get("type") == "item.completed":
+            item = event.get("item") or {}
+            if item.get("type") == "agent_message" and item.get("text"):
+                text = item["text"]
+        elif event.get("type") == "turn.completed":
+            token_usage = event.get("usage") or {}
+            usage.update({
+                "input_tokens": token_usage.get("input_tokens", 0) or 0,
+                "output_tokens": token_usage.get("output_tokens", 0) or 0,
+                "cache_read_tokens": token_usage.get("cached_input_tokens", 0) or 0,
+            })
+
+    if not text:
+        raise RuntimeError("codex subprocess completed without an agent response")
+    return {"text": text.strip(), "usage": usage}
 
 
 async def _call_openai(prompt: str, system: str, model: str, api_key: str, max_tokens: int,

--- a/backend/analyzer/llm_cost.py
+++ b/backend/analyzer/llm_cost.py
@@ -1,5 +1,5 @@
 """LLM pricing and cost calculation, in USD per million tokens, keyed by (provider, model) since the same model can be billed differently across providers (e.g. Anthropic API vs. Claude Code subscription).
-claude_api/openai use static tables (update when models change); openrouter is fetched live (refresh_openrouter_prices); claude_code/ollama are always $0."""
+claude_api/openai use static tables (update when models change); openrouter is fetched live (refresh_openrouter_prices); claude_code/codex_cli/ollama are always $0."""
 import time as _time
 import logging
 from typing import Optional
@@ -58,7 +58,7 @@ PRICING: dict[str, dict[str, dict]] = {
 }
 
 # Providers whose calls are covered by flat subscription / local compute — always $0.
-FREE_PROVIDERS: set[str] = {"claude_code", "ollama"}
+FREE_PROVIDERS: set[str] = {"claude_code", "codex_cli", "ollama"}
 
 # ── OpenRouter live pricing ──────────────────────────────────────────────────
 _OR_PRICES: dict[str, dict] = {}   # slug -> per-Mtok pricing dict
@@ -115,7 +115,7 @@ def calc_cost(provider: str, model: str,
               output_tokens: int = 0,
               cache_read_tokens: int = 0,
               cache_write_tokens: int = 0) -> float:
-    """Calculate USD cost for a single LLM call; returns 0.0 for FREE_PROVIDERS (claude_code, ollama) or an unpriced (provider, model) combo."""
+    """Calculate USD cost for a single LLM call; returns 0.0 for subscription/local providers or an unpriced (provider, model) combo."""
     if provider in FREE_PROVIDERS:
         return 0.0
     p = get_pricing(provider, model)

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -357,7 +357,7 @@ class LlmCallLog(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     created_at = Column(DateTime(timezone=True), default=utcnow, nullable=False)
     purpose = Column(String, nullable=False)  # score_light, score_full, tailor, email, pdf
-    provider = Column(String, nullable=False, default="")  # claude_api, claude_code, openai, ollama
+    provider = Column(String, nullable=False, default="")  # claude_api, claude_code, codex_cli, openai, ollama
     job_id = Column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="SET NULL"), nullable=True)
     model = Column(String, nullable=False, default="")
     input_tokens = Column(Integer, default=0, nullable=False)

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -42,9 +42,9 @@ DEFAULT_SETTINGS = {
     "scoring_rubric": ("Score each resume using these criteria (each 0-20, sum to 0-100):\n1. SKILLS MATCH (weight: 20): How many required technical skills/tools does the candidate have?\n2. EXPERIENCE LEVEL (weight: 20): Does seniority/years match? (entry-level resume for senior role = low)\n3. DOMAIN FIT (weight: 20): Has the candidate worked in the same industry/domain?\n4. ROLE ALIGNMENT (weight: 20): Does the candidate's career trajectory match this role type?\n5. REQUIREMENTS MET (weight: 20): Does the candidate meet stated requirements (education, certs, clearance)?\n\nUse the FULL 0-100 range. 90+ = perfect match. 50-70 = decent with gaps. Below 30 = poor match.\nAvoid clustering scores — differentiate meaningfully between resumes and jobs.", "Editable resume scoring rubric"),
     "scoring_output_light": ('Return ONLY this JSON:\n{\n  "scores": {CV_NAMES_HERE: 0-100},\n  "best_cv": "CV_NAME"\n}', "Light scoring output schema"),
     "scoring_output_full": ('Return ONLY this JSON:\n{\n  "scores": {CV_NAMES_HERE: 0-100},\n  "best_cv": "CV_NAME",\n  "breakdown": {"skills": 0-20, "experience": 0-20, "domain": 0-20, "role": 0-20, "requirements": 0-20},\n  "summary": "2-3 sentence assessment of candidate-job fit",\n  "requirement_mapping": [\n    {"requirement": "JD requirement text", "cv_match": "matching CV line or null", "matched": true/false, "severity": "required or preferred"}\n  ],\n  "keyword_coverage_pct": 0-100,\n  "matched_keywords": ["keyword1", "keyword2"],\n  "missing_keywords": ["keyword3", "keyword4"],\n  "hard_blockers": ["blocker if any"],\n  "ats_tip": "one actionable ATS optimization suggestion"\n}', "Full scoring output schema with keyword analysis"),
-    "llm_provider": ("claude_api", "LLM provider: claude_api, claude_code, openai, ollama"),
+    "llm_provider": ("claude_api", "LLM provider: claude_api, claude_code, codex_cli, openai, ollama, openrouter"),
     "llm_model": ("claude-sonnet-5", "LLM model name"),
-    "llm_api_key": ("", "API key for OpenAI (not needed for Claude API/Ollama)"),
+    "llm_api_key": ("", "API key for API-backed providers (not needed for subscription CLIs or Ollama)"),
     "llm_fallback_provider": ("", "Fallback LLM provider (empty = no fallback)"),
     "llm_fallback_model": ("", "Fallback model name"),
     "llm_fallback_api_key": ("", "API key for fallback provider (OpenAI)"),
@@ -68,6 +68,10 @@ DEFAULT_SETTINGS = {
         {"provider": "claude_code", "model": "claude-opus-4-6"},
         {"provider": "claude_code", "model": "claude-haiku-4-5"},
         {"provider": "claude_code", "model": "claude-fable-5"},
+        {"provider": "codex_cli", "model": "gpt-5.6-sol"},
+        {"provider": "codex_cli", "model": "gpt-5.6-terra"},
+        {"provider": "codex_cli", "model": "gpt-5.6-luna"},
+        {"provider": "codex_cli", "model": "gpt-5.5"},
         {"provider": "openai", "model": "gpt-5.4"},
         {"provider": "openai", "model": "gpt-5.4-mini"},
         {"provider": "openai", "model": "gpt-5.4-nano"},
@@ -354,7 +358,7 @@ INT_SETTING_KEYS = _int_setting_keys()
 
 # Providers the LLM dispatcher knows how to call. "" means "inherit the primary
 # llm_provider", which every per-feature prefix does.
-_LLM_PROVIDERS = {"", "claude_api", "claude_code", "openai", "ollama", "openrouter"}
+_LLM_PROVIDERS = {"", "claude_api", "claude_code", "codex_cli", "openai", "ollama", "openrouter"}
 
 # Depth words. `tailor_auto_quick_score` also honours legacy boolean spellings
 # (see routes_resumes._resolve_chain_score_depth).

--- a/backend/tests/test_codex_cli_provider.py
+++ b/backend/tests/test_codex_cli_provider.py
@@ -1,0 +1,70 @@
+"""Contract tests for the ChatGPT-subscription Codex CLI provider."""
+import json
+from pathlib import Path
+
+import pytest
+
+
+class FakeProcess:
+    def __init__(self, stdout=b"", stderr=b"", returncode=0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.input = None
+
+    async def communicate(self, input=None):
+        self.input = input
+        return self._stdout, self._stderr
+
+
+@pytest.mark.asyncio
+async def test_codex_cli_runs_ephemeral_read_only_and_parses_jsonl(monkeypatch):
+    from backend.analyzer import llm_client
+
+    events = [
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "  matched  "}},
+        {"type": "turn.completed", "usage": {
+            "input_tokens": 81, "cached_input_tokens": 20, "output_tokens": 12,
+        }},
+    ]
+    process = FakeProcess(stdout=("\n".join(json.dumps(e) for e in events) + "\n").encode())
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return process
+
+    monkeypatch.setattr(llm_client.asyncio, "create_subprocess_exec", fake_exec)
+    result = await llm_client._call_codex_cli(
+        "job description", "score against the resume", "gpt-5.6-sol", 600,
+    )
+
+    args = captured["args"]
+    assert args[:2] == ("codex", "exec")
+    assert "--ephemeral" in args
+    assert "--ignore-user-config" in args
+    assert "--ignore-rules" in args
+    assert "--skip-git-repo-check" in args
+    assert args[args.index("--sandbox") + 1] == "read-only"
+    assert args[args.index("--model") + 1] == "gpt-5.6-sol"
+    assert args[-1] == "-"
+    assert Path(args[args.index("-C") + 1]).name.startswith("jobnavigator-codex-")
+    assert process.input == b"score against the resume\n\njob description"
+    assert result == {
+        "text": "matched",
+        "usage": {"input_tokens": 81, "output_tokens": 12,
+                  "cache_read_tokens": 20, "cache_write_tokens": 0},
+    }
+
+
+@pytest.mark.asyncio
+async def test_codex_cli_reports_subprocess_failure(monkeypatch):
+    from backend.analyzer import llm_client
+
+    async def fake_exec(*args, **kwargs):
+        return FakeProcess(stderr=b"login required", returncode=1)
+
+    monkeypatch.setattr(llm_client.asyncio, "create_subprocess_exec", fake_exec)
+    with pytest.raises(RuntimeError, match=r"codex subprocess failed.*login required"):
+        await llm_client._call_codex_cli("prompt", "system", "", 10)

--- a/backend/tests/test_dispatch_non_anthropic_prefix.py
+++ b/backend/tests/test_dispatch_non_anthropic_prefix.py
@@ -33,6 +33,27 @@ async def test_dispatch_concatenates_prefix_for_claude_code(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_concatenates_prefix_for_codex_cli(monkeypatch):
+    """codex_cli receives cached_prefix + prompt combined."""
+    captured = {}
+
+    async def fake_codex_cli(prompt, system, model, max_tokens):
+        captured["prompt"] = prompt
+        return {"text": "ok", "usage": {"input_tokens": 1, "output_tokens": 1,
+                                            "cache_read_tokens": 0, "cache_write_tokens": 0}}
+
+    monkeypatch.setattr("backend.analyzer.llm_client._call_codex_cli", fake_codex_cli)
+    from backend.analyzer.llm_client import _dispatch
+    await _dispatch(
+        provider="codex_cli", model="gpt-5.6-sol", api_key="",
+        prompt="JOB DESCRIPTION", system="rubric scorer", max_tokens=600,
+        cached_prefix="RUBRIC + CVs",
+    )
+
+    assert captured["prompt"] == "RUBRIC + CVs\n\nJOB DESCRIPTION"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_concatenates_prefix_for_openai(monkeypatch):
     """openai provider receives cached_prefix + prompt combined."""
     captured = {}

--- a/backend/tests/test_llm_cost.py
+++ b/backend/tests/test_llm_cost.py
@@ -67,6 +67,14 @@ def test_claude_code_is_free():
     assert cost == 0.0
 
 
+def test_codex_cli_is_free():
+    """codex_cli uses a ChatGPT subscription — always $0 in API-cost stats."""
+    cost = calc_cost("codex_cli", "gpt-5.6-sol",
+                     input_tokens=10000, output_tokens=5000,
+                     cache_read_tokens=2000, cache_write_tokens=0)
+    assert cost == 0.0
+
+
 def test_ollama_is_free():
     """ollama is local — always $0."""
     cost = calc_cost("ollama", "llama3",
@@ -109,4 +117,5 @@ def test_get_pricing_unknown_provider():
 
 def test_free_providers_set():
     assert "claude_code" in FREE_PROVIDERS
+    assert "codex_cli" in FREE_PROVIDERS
     assert "ollama" in FREE_PROVIDERS

--- a/backend/tests/test_r4_contract_settings.py
+++ b/backend/tests/test_r4_contract_settings.py
@@ -143,7 +143,7 @@ def test_patch_settings_rejects_an_unknown_provider(client, key):
     assert "must be one of" in r.json()["detail"]
 
 
-@pytest.mark.parametrize("provider", ["claude_api", "claude_code", "openai",
+@pytest.mark.parametrize("provider", ["claude_api", "claude_code", "codex_cli", "openai",
                                       "ollama", "openrouter", ""])
 def test_patch_settings_accepts_every_known_provider(client, provider):
     assert_clean(client.patch("/api/settings", json={"llm_provider": provider}), 200)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - ./backend:/app/backend
       - ./backups:/app/backups
       - ./backend/.linkedin_api:/root/.linkedin_api
+      - codex_auth:/root/.codex
 
   frontend:
     build:
@@ -83,3 +84,4 @@ volumes:
   pgdata:
   caddy_data:
   caddy_config:
+  codex_auth:

--- a/frontend/src/classic/Settings.jsx
+++ b/frontend/src/classic/Settings.jsx
@@ -249,7 +249,7 @@ export default function SettingsPage() {
             <Info size={15} className="text-gray-400 dark:text-gray-500 cursor-help" />
             <div className="hidden group-hover:block absolute left-6 top-0 z-50 w-80 p-3 text-xs bg-gray-900 text-gray-100 rounded-lg shadow-lg leading-relaxed">
               <p className="font-semibold mb-1.5">Provider &amp; model config (used by every AI feature)</p>
-              <p className="mb-1.5"><b>Primary LLM</b> — the default provider + model every AI feature uses. Claude API uses the settings key (or ANTHROPIC_API_KEY). Claude Code uses your subscription via OAuth (same models as Claude API). OpenAI/Ollama use their keys. <b>OpenRouter</b> reaches every vendor with one key — vendor-prefixed slugs (e.g. <code>anthropic/claude-sonnet-5</code>), no prompt-cache discount.</p>
+              <p className="mb-1.5"><b>Primary LLM</b> — the default provider + model every AI feature uses. Claude API uses the settings key (or ANTHROPIC_API_KEY). Claude Code and Codex CLI use subscription logins. OpenAI/Ollama use their keys. <b>OpenRouter</b> reaches every vendor with one key — vendor-prefixed slugs (e.g. <code>anthropic/claude-sonnet-5</code>), no prompt-cache discount.</p>
               <p><b>Add Custom Model</b> — type to search a provider's live catalog (OpenRouter / OpenAI / Claude) or enter any slug, then Add. Models appear in the dropdowns; the × on a chip deletes one (removals persist).</p>
             </div>
           </div>
@@ -272,6 +272,7 @@ export default function SettingsPage() {
                     className="border rounded px-2 py-1.5 text-sm w-full dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600">
                     <option value="claude_api">Claude API (Anthropic)</option>
                     <option value="claude_code">Claude Code (Subscription)</option>
+                    <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
                     <option value="openai">OpenAI</option>
                     <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -287,7 +288,7 @@ export default function SettingsPage() {
                   </select>
                 </div>
               </div>
-              {!['claude_code', 'ollama'].includes(provider) && (
+              {!['claude_code', 'codex_cli', 'ollama'].includes(provider) && (
                 <div className="mt-2">
                   <label className="block text-[10px] text-gray-500 dark:text-gray-500 mb-0.5">API Key</label>
                   <div className="relative">
@@ -307,7 +308,7 @@ export default function SettingsPage() {
         {/* Custom Models — shared across primary & fallback */}
         {(() => {
           const models = Array.isArray(settings.llm_models_list) ? settings.llm_models_list : []
-          const providerLabels = { claude_api: 'Claude API', claude_code: 'Claude Code', openai: 'OpenAI', ollama: 'Ollama', openrouter: 'OpenRouter' }
+          const providerLabels = { claude_api: 'Claude API', claude_code: 'Claude Code', codex_cli: 'Codex CLI', openai: 'OpenAI', ollama: 'Ollama', openrouter: 'OpenRouter' }
           const canSearch = SEARCHABLE_PROVIDERS.includes(customProvider)
           const liveModels = providerModels[customProvider] || []
           const loadingModels = modelsLoading[customProvider]
@@ -330,6 +331,7 @@ export default function SettingsPage() {
                   className="border rounded px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600">
                   <option value="claude_api">Claude API</option>
                   <option value="claude_code">Claude Code</option>
+                  <option value="codex_cli">Codex CLI</option>
                   <option value="openai">OpenAI</option>
                   <option value="ollama">Ollama</option>
                   <option value="openrouter">OpenRouter</option>
@@ -422,6 +424,7 @@ export default function SettingsPage() {
                     <option value="">Use Primary</option>
                     <option value="claude_api">Claude API (Anthropic)</option>
                     <option value="claude_code">Claude Code (Subscription)</option>
+                    <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
                     <option value="openai">OpenAI</option>
                     <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -438,7 +441,7 @@ export default function SettingsPage() {
                   </select>
                 </div>
               </div>
-              {scProvider && !['claude_code', 'ollama'].includes(scProvider) && (
+              {scProvider && !['claude_code', 'codex_cli', 'ollama'].includes(scProvider) && (
                 <div className="mt-2">
                   <label className="block text-[10px] text-gray-500 dark:text-gray-500 mb-0.5">API Key</label>
                   <div className="relative">
@@ -474,6 +477,7 @@ export default function SettingsPage() {
                     <option value="">None (disabled)</option>
                     <option value="claude_api">Claude API (Anthropic)</option>
                     <option value="claude_code">Claude Code (Subscription)</option>
+                    <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
                     <option value="openai">OpenAI</option>
                     <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -491,7 +495,7 @@ export default function SettingsPage() {
                   </select>
                 </div>
               </div>
-              {provider && !['claude_code', 'ollama'].includes(provider) && (
+              {provider && !['claude_code', 'codex_cli', 'ollama'].includes(provider) && (
                 <div className="mt-2">
                   <label className="block text-[10px] text-gray-500 dark:text-gray-500 mb-0.5">API Key</label>
                   <div className="relative">
@@ -528,7 +532,7 @@ export default function SettingsPage() {
             />
             Prompt Caching (Anthropic)
           </label>
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Send the rubric + Resumes + schema as a cached block so subsequent scoring calls reuse it at ~10× cheaper input tokens. Only active when provider is <code>claude_api</code>; no effect with <code>claude_code</code> or local providers. Disable as a rollback lever.</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Send the rubric + Resumes + schema as a cached block so subsequent scoring calls reuse it at ~10× cheaper input tokens. Only active when provider is <code>claude_api</code>; no effect with subscription CLI or local providers. Disable as a rollback lever.</p>
         </div>
         <div className="mt-4">
           <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Default Scoring Depth</label>
@@ -610,6 +614,7 @@ export default function SettingsPage() {
               <option value="">Use Primary</option>
               <option value="claude_api">Claude API (Anthropic)</option>
               <option value="claude_code">Claude Code (Subscription)</option>
+              <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
               <option value="openai">OpenAI</option>
               <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -636,7 +641,7 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        {settings.cv_tailor_llm_provider && !['claude_code', 'ollama', ''].includes(settings.cv_tailor_llm_provider) && (
+        {settings.cv_tailor_llm_provider && !['claude_code', 'codex_cli', 'ollama', ''].includes(settings.cv_tailor_llm_provider) && (
           <div className="mb-4">
             <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">API Key</label>
             <div className="relative">
@@ -723,6 +728,7 @@ export default function SettingsPage() {
               <option value="">Use Primary</option>
               <option value="claude_api">Claude API (Anthropic)</option>
               <option value="claude_code">Claude Code (Subscription)</option>
+              <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
               <option value="openai">OpenAI</option>
               <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -749,7 +755,7 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        {settings.cover_letter_llm_provider && !['claude_code', 'ollama', ''].includes(settings.cover_letter_llm_provider) && (
+        {settings.cover_letter_llm_provider && !['claude_code', 'codex_cli', 'ollama', ''].includes(settings.cover_letter_llm_provider) && (
           <div className="mb-4">
             <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">API Key</label>
             <div className="relative">
@@ -824,6 +830,7 @@ export default function SettingsPage() {
               <option value="">Use Primary</option>
               <option value="claude_api">Claude API (Anthropic)</option>
               <option value="claude_code">Claude Code (Subscription)</option>
+              <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
               <option value="openai">OpenAI</option>
               <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -965,6 +972,7 @@ export default function SettingsPage() {
               <option value="">Use Primary</option>
               <option value="claude_api">Claude API (Anthropic)</option>
               <option value="claude_code">Claude Code (Subscription)</option>
+              <option value="codex_cli">Codex CLI (ChatGPT Subscription)</option>
               <option value="openai">OpenAI</option>
               <option value="ollama">Ollama (Local)</option>
                     <option value="openrouter">OpenRouter</option>
@@ -991,7 +999,7 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        {settings.email_llm_provider && !['claude_code', 'ollama', ''].includes(settings.email_llm_provider) && (
+        {settings.email_llm_provider && !['claude_code', 'codex_cli', 'ollama', ''].includes(settings.email_llm_provider) && (
           <div className="mb-4">
             <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">API Key</label>
             <div className="relative">

--- a/frontend/src/classic/Stats.jsx
+++ b/frontend/src/classic/Stats.jsx
@@ -128,7 +128,7 @@ function LlmCostPanel() {
         <div className="flex items-center gap-1.5">
           <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">LLM Costs — {days > 0 ? `last ${days} days` : 'all time'}</h2>
           <InfoTip title="How costs are priced">
-            <b>OpenAI</b> and <b>Claude</b> prices are a static table, current as of <b>August 2026</b> (no pricing API exists for them). <b>OpenRouter</b> uses <b>live pricing</b> from its catalog: refreshed when the backend starts, then automatically at most every <b>12 hours</b> (on the next OpenRouter call). <b>Claude Code</b> (subscription) and <b>Ollama</b> (local) count as $0. Cost is computed per call at log time, so past rows keep the price in effect then.
+            <b>OpenAI</b> and <b>Claude</b> prices are a static table, current as of <b>August 2026</b> (no pricing API exists for them). <b>OpenRouter</b> uses <b>live pricing</b> from its catalog: refreshed when the backend starts, then automatically at most every <b>12 hours</b> (on the next OpenRouter call). <b>Claude Code</b>, <b>Codex CLI</b> (subscriptions), and <b>Ollama</b> (local) count as $0. Cost is computed per call at log time, so past rows keep the price in effect then.
           </InfoTip>
         </div>
         <select

--- a/frontend/src/screens/Settings.jsx
+++ b/frontend/src/screens/Settings.jsx
@@ -11,6 +11,7 @@ import '../theme.css'
 const PROVIDERS = [
   ['claude_api', 'Claude API (Anthropic)'],
   ['claude_code', 'Claude Code (Subscription)'],
+  ['codex_cli', 'Codex CLI (ChatGPT Subscription)'],
   ['openai', 'OpenAI'],
   ['ollama', 'Ollama (Local)'],
   ['openrouter', 'OpenRouter'],
@@ -19,7 +20,7 @@ const PROVIDER_LABEL = Object.fromEntries(PROVIDERS)
 // providers whose catalog /api/llm/models can search live
 const SEARCHABLE = ['openrouter', 'openai', 'claude_api', 'claude_code']
 // providers that need no key
-const KEYLESS = ['claude_code', 'ollama', '']
+const KEYLESS = ['claude_code', 'codex_cli', 'ollama', '']
 
 // The value rows' fields are `Input` now (adornment slot and all), so the box
 // lives in ui.jsx with every other field. What is left here is the type these
@@ -347,7 +348,7 @@ export default function Settings() {
       ['models', 'AI', 'Models', '', [
         { kind: 'pair', label: 'Primary provider · model', help: 'Every AI feature uses this pair unless overridden below.',
           pKey: 'llm_provider', mKey: 'llm_model',
-          info: "Providers: Claude API, Claude Code, OpenAI, Ollama (local), OpenRouter. The model list shows that provider's models, including any you added under Model catalog. OpenRouter covers every vendor with one key but has no prompt-cache discount." },
+          info: "Providers: Claude API, Claude Code, Codex CLI (your ChatGPT subscription), OpenAI, Ollama (local), OpenRouter. The model list shows that provider's models, including any you added under Model catalog. OpenRouter covers every vendor with one key but has no prompt-cache discount." },
         B('API key', 'API key for the primary provider.', 'llm_api_key', { secret: true, mono: true, w: '340px', hide: () => KEYLESS.includes(val('llm_provider', 'claude_api')) }),
         LLM('Scoring', 'Model that scores new jobs against your résumés.', 'scoring_llm'),
         LLM('Scoring fallback', 'Retries scoring once on error or rate limit — scoring only.', 'llm_fallback',

--- a/frontend/src/screens/Stats.jsx
+++ b/frontend/src/screens/Stats.jsx
@@ -565,7 +565,7 @@ export default function Stats() {
           <Card style={{ height: 300, padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0, overflow: 'hidden' }}>
             <div style={{ flex: '0 0 auto', display: 'flex', alignItems: 'baseline', gap: 9, lineHeight: '24px' }}>
               <Heading strong size={17}>LLM costs</Heading>
-              <Helper title="OpenAI and Claude pricing info comes from a fixed table, OpenRouter from its catalog (updated every 12 h), Claude Code and Ollama counted as $0. Each call is priced when it is logged."
+              <Helper title="OpenAI and Claude pricing info comes from a fixed table, OpenRouter from its catalog (updated every 12 h), Claude Code, Codex CLI, and Ollama counted as $0. Each call is priced when it is logged."
                 style={{ cursor: 'help', borderBottom: '1px dotted var(--line-strong)' }}>how priced?</Helper>
               <span style={{ marginLeft: 'auto', alignSelf: 'center', display: 'flex', gap: 3 }}>
                 {PERIODS.map(([id, label]) => {


### PR DESCRIPTION
JobNavigator currently supports OpenAI API keys and Claude Code subscriptions, but it cannot use an existing ChatGPT/Codex subscription. This adds a `codex_cli` provider that invokes `codex exec`, making ChatGPT subscription login available for scoring, tailoring, cover letters, autofill, and email features.

The provider runs each request as an ephemeral session in an empty read-only workspace, ignores host config and project rules, parses JSONL responses and token usage, and counts subscription calls as $0 in API-cost reporting. Docker installs Codex CLI 0.154.0 and persists device authentication in a dedicated `codex_auth` volume. Both settings interfaces expose the provider and seeded Codex models.

Setup after starting the stack:

```bash
docker compose exec backend codex login --device-auth
```

Validation:

- 170 focused backend tests passed; 1 expected xfail
- Backend and frontend production Docker images built successfully
- `docker compose config` validated the auth volume
- Manual end-to-end call through `codex_cli` with `gpt-5.6-sol` succeeded and returned parsed token usage
