### PR TITLE
Log application: add a job to the feed at New or Saved, and tailor from the modal

### DIFF
--- a/backend/api/routes_jobs.py
+++ b/backend/api/routes_jobs.py
@@ -645,6 +645,61 @@ async def save_from_extension(body: dict, db: Session = Depends(get_db)):
     return out
 
 
+# Statuses a hand-added feed job may start at. `applied` is not one of them:
+# POST /applications owns that path and writes the Application row with it.
+MANUAL_JOB_STATUSES = {"new", "saved"}
+
+
+@router.post("/manual")
+def create_manual_job(body: dict, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
+    """Add one job to the feed by hand (Log-application modal, statuses new/saved), with no application attached; an already-known posting keeps the status it has and is returned with created=false."""
+    title = str_field(body, "title")
+    company = str_field(body, "company")
+    url = str_field(body, "url")
+    status = str_field(body, "status") or "new"
+    if not title or not company or not url:
+        raise HTTPException(status_code=400, detail="title, company, and url are required")
+    if status not in MANUAL_JOB_STATUSES:
+        raise HTTPException(status_code=400,
+                            detail=f"status must be one of {sorted(MANUAL_JOB_STATUSES)}")
+
+    # Same two-layer dedup as save-from-extension: external_id (URL), then
+    # content_hash (company+title) for the same posting reached by another URL.
+    external_id = make_external_id(company, title, url)
+    content_hash = make_content_hash(company, title)
+    existing = db.query(Job).filter(
+        (Job.external_id == external_id) | (Job.content_hash == content_hash)
+    ).first()
+    if existing:
+        # Report the row, change nothing: an `applied` or `ignored` posting must
+        # not fall back to `new` because the user pasted its URL a second time.
+        return {"id": str(existing.id), "created": False, "status": existing.status}
+
+    job = Job(
+        external_id=external_id,
+        content_hash=content_hash,
+        company=company,
+        title=title,
+        url=url,
+        source="manual",   # same marker the hand-logged application path uses
+        status=status,
+        # `saved` and status='saved' move together everywhere else in the feed.
+        saved=(status == "saved"),
+        seen=True,         # the user typed this row in; it is not an unseen find
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    # The enrichment the hand-logged application path runs: without it the first
+    # score, tailor or cover letter pays for the fetch.
+    from backend.api.routes_applications import _cache_job_page, _fetch_and_store_description
+    background_tasks.add_task(_cache_job_page, str(job.id), url)
+    background_tasks.add_task(_fetch_and_store_description, str(job.id), url)
+
+    return {"id": str(job.id), "created": True, "status": job.status}
+
+
 # Column types for the three fields both job writers accept. Without this a
 # `{"saved": "banana"}` reaches the driver and 500s (R4-T1-11); `status` stays a
 # free string on purpose (the feed invents statuses like "ignored").

--- a/backend/tests/test_routes_jobs_manual.py
+++ b/backend/tests/test_routes_jobs_manual.py
@@ -1,0 +1,69 @@
+"""POST /jobs/manual adds one hand-typed posting to the feed and creates no application; create_manual_job is a plain route function taking its Session as a parameter, so tests call it directly (no backend.main, no TestClient)."""
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from backend.api.routes_jobs import create_manual_job
+from backend.models.db import Application, Job
+
+
+def _add(db, **over):
+    body = {"title": "Senior Backend Engineer", "company": "Acme",
+            "url": "https://acme.test/jobs/1"}
+    body.update(over)
+    return create_manual_job(body, BackgroundTasks(), db=db)
+
+
+def test_new_status_writes_the_row(test_db):
+    out = _add(test_db, status="new")
+
+    assert out["created"] is True and out["status"] == "new"
+    job = test_db.query(Job).one()
+    assert (job.source, job.status, job.saved, job.seen) == ("manual", "new", False, True)
+    # the modal's own path — a feed job carries no application
+    assert test_db.query(Application).count() == 0
+
+
+def test_saved_status_moves_the_saved_flag_with_it(test_db):
+    """The feed writes `saved: true` with status='saved'; this path must match."""
+    _add(test_db, status="saved")
+    assert test_db.query(Job).one().saved is True
+
+
+def test_status_defaults_to_new(test_db):
+    assert _add(test_db)["status"] == "new"
+
+
+@pytest.mark.parametrize("status", ["applied", "interview", "skip", "banana"])
+def test_application_stages_and_junk_are_refused(test_db, status):
+    """`applied` belongs to POST /applications, which also writes the Application row."""
+    with pytest.raises(HTTPException) as e:
+        _add(test_db, status=status)
+    assert e.value.status_code == 400
+    assert test_db.query(Job).count() == 0
+
+
+@pytest.mark.parametrize("blank", ["title", "company", "url"])
+def test_the_three_required_fields(test_db, blank):
+    with pytest.raises(HTTPException) as e:
+        _add(test_db, **{blank: ""})
+    assert e.value.status_code == 400
+
+
+def test_a_known_posting_keeps_its_status(test_db):
+    """Pasting the URL of a job already applied to must not send it back to `new`."""
+    _add(test_db, status="new")
+    test_db.query(Job).one().status = "applied"
+    test_db.commit()
+
+    out = _add(test_db, status="saved")
+
+    assert out["created"] is False and out["status"] == "applied"
+    assert test_db.query(Job).count() == 1
+
+
+def test_enrichment_is_queued_for_a_new_row(test_db):
+    """Without the JD fetch the first score, tailor or cover letter pays for it."""
+    bg = BackgroundTasks()
+    create_manual_job({"title": "Dev", "company": "Acme", "url": "https://acme.test/j/2"},
+                      bg, db=test_db)
+    assert [t.func.__name__ for t in bg.tasks] == ["_cache_job_page", "_fetch_and_store_description"]

--- a/frontend/src/screens/Applications.jsx
+++ b/frontend/src/screens/Applications.jsx
@@ -48,6 +48,15 @@ const STAGES = [
 const STAGE = Object.fromEntries(STAGES.map((s) => [s.id, s]))
 // legacy rows (ghosted / withdrawn) have no stage of their own — closed, so they list under Rejected
 const groupOf = (status) => (STAGE[status] ? status : 'rejected')
+// The Log modal writes one of two rows. `new`/`saved` are Job.status values and go to
+// POST /jobs/manual as a feed job with no application; the rest are Application.status
+// stages and go to POST /applications, which writes the job too.
+const LOG_JOB_STATUSES = ['new', 'saved']
+const LOG_STATUSES = [
+  { id: 'new', label: 'New', hint: 'Feed only — decide later' },
+  { id: 'saved', label: 'Saved', hint: 'Feed only — shortlisted' },
+  ...STAGES.filter((s) => s.id !== 'rejected'),
+]
 const SORTS = [['recent', 'Recent activity'], ['oldest', 'Waiting longest'], ['company', 'Company name']]
 const isStale = (a) => daysSince(a.updated_at) > 7 && ['applied', 'interview'].includes(a.status)
 
@@ -132,7 +141,7 @@ export default function Applications() {
   const dropLog = () => { logDirty.current = false; setLogOpen(false) }
   const closeLog = () => {
     if (!logDirty.current) { dropLog(); return }
-    setConfirm({ title: 'Discard this application?', body: 'Everything typed will be lost.', label: 'Discard', danger: true, onConfirm: () => { setConfirm(null); dropLog() } })
+    setConfirm({ title: 'Discard this draft?', body: 'Everything typed will be lost.', label: 'Discard', danger: true, onConfirm: () => { setConfirm(null); dropLog() } })
   }
   useEffect(() => {
     const onDoc = () => closeAll()
@@ -497,7 +506,10 @@ export default function Applications() {
       {/* the first load(id) forces open the just-logged application (nothing else could be
           selected yet); the 5s follow-up (picking up a still-processing score) must NOT
           force it again — the user may have moved on by then — so it's a plain load(). */}
-      {logOpen && <LogModal onClose={closeLog} onDirty={(v) => { logDirty.current = v }} onSaved={(id) => { dropLog(); load(id); setTimeout(() => load(), 5000); window.dispatchEvent(new CustomEvent('jn:counts-changed')) }} pushToast={pushToast} />}
+      {logOpen && <LogModal onClose={closeLog} onDirty={(v) => { logDirty.current = v }} onSaved={(id) => { dropLog(); load(id); setTimeout(() => load(), 5000); window.dispatchEvent(new CustomEvent('jn:counts-changed')) }}
+        // a feed job has no row on this screen — hand it to the Feed, where its status lives
+        onJobSaved={(jobId, existing) => { dropLog(); pushToast({ kind: 'progress', msg: existing ? 'Already in the Job Feed — opened it.' : 'Added to the Job Feed.' }); window.dispatchEvent(new CustomEvent('jn:counts-changed')); navigate(`/feed?job=${jobId}`) }}
+        pushToast={pushToast} />}
       {confirm && <ConfirmDialog {...confirm} onCancel={() => setConfirm(null)} />}
       <ToastStack toasts={toasts} onClose={dismissToast} />
     </div>
@@ -728,18 +740,20 @@ function PrepModal({ prep, company, copied, onCopy, onClose }) {
 }
 
 // ── log-application modal ────────────────────────────────────────────────────
-function LogModal({ onClose, onSaved, pushToast, onDirty }) {
+function LogModal({ onClose, onSaved, onJobSaved, pushToast, onDirty }) {
   const [url, setUrl] = useState('')
   const [title, setTitle] = useState('')
   const [company, setCompany] = useState('')
   const [resumes, setResumes] = useState([])
-  const [cv, setCv] = useState('')
-  const [stage, setStage] = useState('applied')
+  const [cv, setCv] = useState('')                  // a résumé id: the API takes the name, the tailor call the id
+  const [status, setStatus] = useState('applied')
   const [when, setWhen] = useState(() => { const t = new Date(), p = (n) => String(n).padStart(2, '0'); return `${t.getFullYear()}-${p(t.getMonth() + 1)}-${p(t.getDate())}` })   // local date, not UTC
   const [notes, setNotes] = useState('')
   useEffect(() => { onDirty?.(!!(url.trim() || title.trim() || company.trim() || notes.trim())) }, [url, title, company, notes])
   const [busy, setBusy] = useState(false)
   const [reading, setReading] = useState(false)
+  const isApp = !LOG_JOB_STATUSES.includes(status)
+  const cvName = resumes.find((r) => r.id === cv)?.name || ''
 
   // The chips are the modal's only way to attach a résumé; an empty list must not read as
   // "you have no résumés" when the user is just here to log an application.
@@ -770,7 +784,25 @@ function LogModal({ onClose, onSaved, pushToast, onDirty }) {
     }
   }
 
-  const save = async () => {
+  // Writes the row and reports {jobId, done}: `done` is what the screen does with it —
+  // select the new application, or open the feed at the new job.
+  const persist = async (attached) => {
+    const body = { url: url.trim(), title: title.trim(), company: company.trim() }
+    if (!isApp) {
+      const { data } = await api.post('/jobs/manual', { ...body, status })
+      return { jobId: data.id, done: () => onJobSaved(data.id, !data.created) }
+    }
+    const { data } = await api.post('/applications', {
+      ...body,
+      cv_version_used: attached || null, notes: notes.trim() || null,
+      status, applied_at: when ? new Date(when + 'T12:00:00').toISOString() : null,   // local noon, never the previous UTC day
+    })
+    return { jobId: data.job_id, done: () => onSaved(data.id) }
+  }
+
+  // `tailorFrom` is a base résumé row {id, name}, or null for a plain save. The row is
+  // saved first either way, because tailoring needs the job id.
+  const submit = async (tailorFrom) => {
     if (!title.trim() || !company.trim() || !url.trim()) {
       pushToast({ kind: 'error', msg: !url.trim() ? 'The posting URL is required — it identifies the job' : 'Title and company are required' })
       const first = [url, title, company].findIndex((v) => !v.trim()); document.querySelectorAll('input[placeholder]')[first]?.focus()
@@ -778,25 +810,30 @@ function LogModal({ onClose, onSaved, pushToast, onDirty }) {
     }
     setBusy(true)
     try {
-      const { data } = await api.post('/applications', {
-        url: url.trim(), title: title.trim(), company: company.trim(),
-        cv_version_used: cv || null, notes: notes.trim() || null,
-        status: stage, applied_at: when ? new Date(when + 'T12:00:00').toISOString() : null,   // local noon, never the previous UTC day
-      })
-      onSaved(data.id)
+      const { jobId, done } = await persist(tailorFrom?.name || cvName)
+      if (tailorFrom && jobId) {
+        // A failed tailor must not lose the row that is already saved — report it and go on.
+        try {
+          await api.post('/resumes/tailor', { base_resume_id: tailorFrom.id, job_id: jobId })
+          pushToast({ kind: 'progress', msg: `Tailoring ${tailorFrom.name} for "${title.trim()}"…` })
+        } catch (e) { console.error(e); pushToast({ kind: 'error', msg: 'Saved, but tailoring could not start' + errSuffix(e) }) }
+      }
+      done()
     } catch (e) {
       const existing = e.response?.status === 409 ? e.response?.data?.detail?.application_id : null
       if (existing) { pushToast({ kind: 'progress', msg: 'Already logged — opened the existing application.' }); onSaved(existing); return }
-      pushToast({ kind: 'error', msg: 'Could not save this application' + errSuffix(e) }); setBusy(false)
+      pushToast({ kind: 'error', msg: `Could not save this ${isApp ? 'application' : 'job'}` + errSuffix(e) }); setBusy(false)
     }
   }
 
   return (
     // escape={false}: as PrepModal — the screen owns Escape for its overlays.
-    <ModalPanel width={520} title="Log application" onClose={onClose} escape={false} zIndex={60} style={{ overflow: 'hidden' }}>
+    <ModalPanel width={520} title={isApp ? 'Log application' : 'Add job to feed'} onClose={onClose} escape={false} zIndex={60} style={{ overflow: 'hidden' }}>
         <HeaderRow align="stretch" style={{ flexDirection: 'column', gap: 3 }}>
-          <Heading className="v2-dialogtitle">Log application</Heading>
-          <Helper style={{ textWrap: 'pretty' }}>For applications made outside the app. Jobs marked Applied in the Feed are logged automatically.</Helper>
+          <Heading className="v2-dialogtitle">{isApp ? 'Log application' : 'Add job to feed'}</Heading>
+          <Helper style={{ textWrap: 'pretty' }}>{isApp
+            ? 'For applications made outside the app. Jobs marked Applied in the Feed are logged automatically.'
+            : 'Adds the posting to the Job Feed at this status. No application, date or notes are stored.'}</Helper>
         </HeaderRow>
         <div className="v2-scroll" style={{ padding: '15px 22px', display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 470, overflow: 'auto' }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
@@ -815,35 +852,48 @@ function LogModal({ onClose, onSaved, pushToast, onDirty }) {
             </div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <Label>Applied with</Label>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+            <Label>{isApp ? 'Applied with' : 'Tailor from'}</Label>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 5 }}>
               {resumes.map((r) => {
-                const on = cv === r.name
-                return <Pill key={r.id} size="sm" on={on} onClick={() => setCv(on ? '' : r.name)}>{r.name}</Pill>
+                const on = cv === r.id
+                return (
+                  <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                    <Pill size="sm" on={on} onClick={() => setCv(on ? '' : r.id)}>{r.name}</Pill>
+                    {/* the trigger sits opposite its résumé and saves first, since tailoring needs the job id */}
+                    <Pill size="sm" disabled={busy} onClick={() => { setCv(r.id); submit(r) }}
+                      title={`Save, then tailor a copy of ${r.name} for this job`}>
+                      <span style={{ color: 'var(--ai)' }}>✦</span>Tailor
+                    </Pill>
+                  </div>
+                )
               })}
             </div>
+            <Helper>✦ saves the row first, then tailors a copy of that résumé in the background.</Helper>
           </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <Label>Status</Label>
+            <Segmented value={status} onChange={setStatus} ariaLabel="Status"
+              options={LOG_STATUSES.map((s) => ({ value: s.id, label: s.label, hint: s.hint }))} />
+          </div>
+          {/* a feed job holds neither of these — the Job row has no date and no notes column */}
+          {isApp && (<>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 9 }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 5, minWidth: 0 }}>
-            <Label>Stage</Label>
-            <Segmented value={stage} onChange={setStage} ariaLabel="Stage"
-              options={['applied', 'interview', 'offer'].map((id) => ({ value: id, label: STAGE[id].label }))} />
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 5, minWidth: 0 }}>
-            <Label>Applied on</Label>
-            <Input type="date" value={when} onChange={setWhen} ariaLabel="Applied on" />
-          </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5, minWidth: 0 }}>
+              <Label>Applied on</Label>
+              <Input type="date" value={when} onChange={setWhen} ariaLabel="Applied on" />
+            </div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
             <Label>Notes</Label>
             <Textarea value={notes} onChange={setNotes} placeholder="Optional — referral, recruiter contact…"
               ariaLabel="Notes" rows={2} style={{ minHeight: 52 }} />
           </div>
+          </>)}
         </div>
         <FooterRow bg="page">
-          <Helper>A copy of the posting is saved with the application</Helper>
+          <Helper>A copy of the posting is saved with the {isApp ? 'application' : 'job'}</Helper>
           <Button variant="secondary" size="sm" onClick={onClose} style={{ marginLeft: 'auto' }}>Cancel</Button>
-          <Button size="sm" onClick={save} busy={busy}>{busy ? 'Saving…' : 'Save application'}</Button>
+          <Button size="sm" onClick={() => submit(null)} busy={busy}>{busy ? 'Saving…' : (isApp ? 'Save application' : 'Save job')}</Button>
         </FooterRow>
     </ModalPanel>
   )


### PR DESCRIPTION
## Why

The *Log application* modal had one exit: an `Application` row at `applied`, `interview` or `offer`. A link the user wanted to keep and decide on later had nowhere to go, and nothing in the modal could start a tailored copy for it.

## Backend — `POST /jobs/manual`

Writes one hand-typed `Job` and no `Application`.

- Accepts `new` and `saved` only. `applied` is a 400 — that path belongs to `POST /applications`, which writes the job too.
- Dedups on `external_id`, then `content_hash`, the same two layers `save-from-extension` uses.
- A posting the feed already holds keeps the status it has and comes back with `created: false`. An `applied` row does not fall back to `new` because its URL was pasted a second time.
- `saved` moves with `status='saved'`, as everywhere else in the feed.
- Queues the page cache and the description fetch (#7's `_fetch_and_store_description`), so the first score, tailor or cover letter does not pay for them.

`skip` and `ignored` are left out on purpose: adding a link in order to hide it has no use.

## Frontend — the modal

- `Stage` becomes `Status` and carries `New` and `Saved` beside the three stages.
- At those two statuses the title, the helper line and the save button change, the `Applied on` and `Notes` fields step aside — a `Job` row holds neither — and the screen opens the Feed at the new row.
- Every base résumé carries a ✦ *Tailor* trigger opposite it. The trigger saves the row first, because tailoring needs the job id, then tailors a copy in the background. A failed tailor reports itself and keeps the saved row.
- The résumé name travels to `submit()` as an argument. `setCv()` has not landed when `submit()` runs, so state would be read empty and the application would save without `cv_version_used`.

## Tests

- `backend/tests/test_routes_jobs_manual.py` — 12 new tests: the two accepted statuses, the `saved` flag, the default, the refused stages, the three required fields, the known-posting rule, and the queued enrichment.
- Full backend suite on this branch: **2283 passed**, 4 skipped, 13 xfailed. The one failure, `test_r4_live_contract.py::test_protected_routes_require_a_key`, belongs to the running stack, not to this branch: the live server accepts an empty `X-API-Key`.
- `npm run build` ✓ · `npm test` 193 passed.

Verified by hand in the running app.

<img width="536" height="597" alt="image" src="https://github.com/user-attachments/assets/00919c12-1ff1-44aa-a9d6-39d40cdbde6d" />
