### PR TITLE
Auto-scoring and the daily digest: compare json columns as json, not jsonb

### DIFF
--- a/backend/analyzer/cv_scorer.py
+++ b/backend/analyzer/cv_scorer.py
@@ -474,6 +474,18 @@ def _find_company_for_job(db, job: Job):
     return find_company_by_name(db, job.company)
 
 
+def unscored_filter():
+    """SQL predicate for "this job carries no scores yet".
+
+    Job.cv_scores is Column(JSON), which Postgres builds as native `json`,
+    and Postgres has no `json = jsonb` operator. Compare the rendered text
+    instead -- the same predicate /api/jobs/feed-stats uses. A `'{}'::jsonb`
+    literal here raises UndefinedFunction and fails the whole scoring pass.
+    """
+    from sqlalchemy import cast, Text
+    return (Job.cv_scores == None) | (cast(Job.cv_scores, Text) == "{}")
+
+
 async def analyze_unscored_jobs(status: str = "saved"):
     """Score all unscored jobs against uploaded CVs in batches of 20; status='saved' scores saved jobs, status='new' scores new jobs from auto_scoring_depth != 'off' entities only.
 
@@ -484,7 +496,7 @@ async def analyze_unscored_jobs(status: str = "saved"):
     whole run.
     """
     from types import SimpleNamespace
-    from sqlalchemy import or_, text, func
+    from sqlalchemy import or_, func
     from backend.models.db import Search, Company as CompanyModel
 
     batch_size = 20
@@ -542,9 +554,7 @@ async def analyze_unscored_jobs(status: str = "saved"):
         needs_fetch = []  # (job_ref, cv_texts, depth, url)
         db = SessionLocal()
         try:
-            q = db.query(Job).filter(
-                (Job.cv_scores == None) | (Job.cv_scores == text("'{}'::jsonb")),
-            )
+            q = db.query(Job).filter(unscored_filter())
             if status == "saved":
                 q = q.filter(Job.saved == True)
             else:

--- a/backend/job_monitor.py
+++ b/backend/job_monitor.py
@@ -2,6 +2,7 @@
 import asyncio
 import contextvars
 import logging
+import re
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -175,10 +176,31 @@ _run_failure: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
 )
 
 
+# A DBAPI error string carries the failed statement, its bound parameters and
+# the driver module path. JobRun.error stored all three, and
+# /api/monitor/history returned them to the browser. Reduce the text to the
+# message before it is stored, and again before it is returned, because rows
+# written before this fix still hold the raw string.
+MAX_RUN_ERROR_CHARS = 1000
+_SQL_BLOCK = "[SQL:"
+_DRIVER_PREFIX_RE = re.compile(r"^\((?:\w+\.)+(\w+)\)\s*")
+
+
+def sanitize_run_error(error: Optional[str]) -> Optional[str]:
+    """Return the message of a run error without the SQL, the parameters or the driver module path."""
+    if error is None:
+        return None
+    text = str(error).split(_SQL_BLOCK, 1)[0].strip()
+    text = _DRIVER_PREFIX_RE.sub(r"\1: ", text)
+    if len(text) > MAX_RUN_ERROR_CHARS:
+        text = text[:MAX_RUN_ERROR_CHARS].rstrip() + "..."
+    return text or None
+
+
 def mark_run_failed(reason: str) -> None:
     """Flag the currently tracked run as failed while still returning a summary."""
     if reason:
-        _run_failure.set(str(reason)[:1000])
+        _run_failure.set(str(reason)[:MAX_RUN_ERROR_CHARS])
 
 
 def _take_run_failure() -> Optional[str]:
@@ -267,7 +289,7 @@ def _finish_job_run(run_id: uuid.UUID, status: str, result_summary: Optional[str
             started = run.started_at if run.started_at.tzinfo else run.started_at.replace(tzinfo=timezone.utc)
             run.duration_seconds = round((now - started).total_seconds(), 1)
             run.result_summary = result_summary
-            run.error = error
+            run.error = sanitize_run_error(error)
             db.commit()
     finally:
         db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.models.db import create_tables, SessionLocal, Setting, JobRun
 from backend.seed import run_seeds
 from backend.config import INITIAL_API_KEY, TELEGRAM_BOT_TOKEN
-from backend.job_monitor import launch_background, JobAlreadyRunningError, get_all_running, is_running, _get_running_by_job_type, cleanup_stale_runs
+from backend.job_monitor import launch_background, JobAlreadyRunningError, get_all_running, is_running, _get_running_by_job_type, cleanup_stale_runs, sanitize_run_error
 
 from backend.api.routes_settings import router as settings_router
 from backend.api.routes_jobs import router as jobs_router
@@ -1144,7 +1144,7 @@ def get_run_history(limit: Annotated[int, Query(ge=0, le=1000)] = 30, offset: in
                 "finished_at": r.finished_at.isoformat() if r.finished_at else None,
                 "duration_seconds": r.duration_seconds,
                 "result_summary": r.result_summary,
-                "error": r.error,
+                "error": sanitize_run_error(r.error),
                 "meta": r.meta,
             }
             for r in runs
@@ -1170,7 +1170,7 @@ def get_run_detail(run_id: str):
             "finished_at": r.finished_at.isoformat() if r.finished_at else None,
             "duration_seconds": r.duration_seconds,
             "result_summary": r.result_summary,
-            "error": r.error,
+            "error": sanitize_run_error(r.error),
             "meta": r.meta,
         }
     finally:

--- a/backend/notifier/telegram.py
+++ b/backend/notifier/telegram.py
@@ -13,6 +13,15 @@ logger = logging.getLogger("jobnavigator.telegram")
 BASE_URL = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}"
 
 
+# Highest numeric value in jobs.cv_scores, compared against :threshold.
+# cv_scores is Column(JSON) -> native `json` in Postgres, and the jsonb_*
+# functions have no `json` overload, so every reference carries an explicit
+# cast. seed.py casts the same column for the same reason.
+STRONG_MATCH_SQL = (
+    "(SELECT COALESCE(MAX(v::numeric), 0) FROM jsonb_each_text(CASE WHEN jsonb_typeof(cv_scores::jsonb) = 'object' THEN cv_scores::jsonb ELSE '{}'::jsonb END) AS t(k, v) WHERE v ~ '^[0-9]+(\\.[0-9]+)?$') >= :threshold"
+)
+
+
 def _get_chat_id() -> str:
     """Read chat_id from settings table."""
     db = SessionLocal()
@@ -256,9 +265,7 @@ async def send_digest():
         from sqlalchemy import text as sa_text
         strong = db.query(Job).filter(
             Job.discovered_at >= yesterday_start,
-        ).filter(sa_text(
-            "(SELECT COALESCE(MAX(v::numeric), 0) FROM jsonb_each_text(CASE WHEN jsonb_typeof(COALESCE(cv_scores, '{}'::jsonb)) = 'object' THEN cv_scores ELSE '{}'::jsonb END) AS t(k, v) WHERE v ~ '^[0-9]+(\\.[0-9]+)?$') >= :threshold"
-        ).bindparams(threshold=threshold)).count()
+        ).filter(sa_text(STRONG_MATCH_SQL).bindparams(threshold=threshold)).count()
 
         active_statuses = ["applied", "interview"]
         active_apps = db.query(Application).filter(Application.status.in_(active_statuses)).count()

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -610,6 +610,8 @@ def run_migrations(db):
         "ALTER TABLE job_runs ADD CONSTRAINT job_runs_target_job_id_fkey FOREIGN KEY (target_job_id) REFERENCES jobs(id) ON DELETE SET NULL",
         "CREATE INDEX IF NOT EXISTS ix_job_runs_target_job_id ON job_runs(target_job_id)",
         """ALTER TABLE companies ADD COLUMN IF NOT EXISTS selected_resume_ids JSONB DEFAULT '[]'::jsonb""",
+        # ADD COLUMN is a no-op where create_all() already built the column from
+        # Column(JSON), so it can be native `json` here too. Cast every reference.
         # Translate selected_cv_ids → selected_resume_ids by matching CV.version to Resume.name.
         # Idempotent: only runs while selected_cv_ids still exists and selected_resume_ids is empty.
         """DO $$
@@ -623,13 +625,13 @@ BEGIN
         SELECT co.id AS cid,
                jsonb_agg(r.id::text) AS ids
           FROM companies co
-          CROSS JOIN LATERAL jsonb_array_elements_text(co.selected_cv_ids) AS cid_str(val)
+          CROSS JOIN LATERAL jsonb_array_elements_text(co.selected_cv_ids::jsonb) AS cid_str(val)
           JOIN cvs cv ON cv.id::text = cid_str.val
           JOIN resumes r ON r.name = cv.version AND r.is_base = TRUE
          GROUP BY co.id
       ) AS translated
      WHERE c.id = translated.cid
-       AND (c.selected_resume_ids IS NULL OR c.selected_resume_ids = '[]'::jsonb);
+       AND (c.selected_resume_ids IS NULL OR c.selected_resume_ids::jsonb = '[]'::jsonb);
   END IF;
 END $$;""",
         """ALTER TABLE companies DROP COLUMN IF EXISTS selected_cv_ids""",

--- a/backend/tests/test_cv_scorer_analyze_unscored.py
+++ b/backend/tests/test_cv_scorer_analyze_unscored.py
@@ -50,18 +50,6 @@ def scorer_ready_db(test_db, monkeypatch):
     monkeypatch.setattr(scorer, "_get_scoring_semaphore",
                         lambda: asyncio.Semaphore(5))
 
-    # analyze_unscored_jobs builds a query using text("'{}'::jsonb") — Postgres-only syntax that
-    # fails under SQLite; rewritten below to a no-op predicate that matches no rows.
-    from sqlalchemy import text as _sa_text, sql as _sa_sql
-    def _safe_text(expr):
-        if expr == "'{}'::jsonb":
-            # Empty-string literal — matches no real cv_scores rows under SQLite
-            return _sa_text("''")
-        return _sa_text(expr)
-    # The function imports text from sqlalchemy inside its body, so patch the module attribute.
-    import sqlalchemy as _sa
-    monkeypatch.setattr(_sa, "text", _safe_text)
-
     return {"db": test_db, "Session": TestSession, "resume": resume}
 
 
@@ -83,7 +71,7 @@ async def test_analyze_unscored_jobs_only_scores_entities_with_auto_scoring(scor
     desc_on = "SCORE_ME_ON: Senior product manager position. " + ("Detail. " * 10)
     desc_off = "SCORE_ME_OFF: Senior product manager position. " + ("Detail. " * 10)
 
-    # cv_scores=sa_null() so the IS NULL branch of the unscored filter matches (the PG jsonb branch is a no-op here).
+    # cv_scores=sa_null() so the IS NULL branch of unscored_filter() matches.
     job_on = Job(external_id="j1", content_hash="h1", company="ScoreOnCo",
                  title="Senior PM", url="https://x.com/1", status="new",
                  description=desc_on, cv_scores=sa_null())

--- a/backend/tests/test_digest_strong_match_sql.py
+++ b/backend/tests/test_digest_strong_match_sql.py
@@ -1,0 +1,35 @@
+"""The daily digest's strong-match subquery must cast cv_scores to jsonb.
+
+`jobs.cv_scores` is `Column(JSON)` -> native `json` in Postgres, and the
+`jsonb_*` functions have no `json` overload. An uncast reference made
+`send_digest` raise `COALESCE could not convert type jsonb to json`, so the
+digest reported nothing every day. Same failure class as `unscored_filter`.
+"""
+import os
+import re
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from backend.notifier.telegram import STRONG_MATCH_SQL
+
+
+def test_every_cv_scores_reference_is_cast_to_jsonb():
+    """No bare `cv_scores` may reach a jsonb function or a jsonb literal."""
+    bare = [m.start() for m in re.finditer(r"cv_scores(?!::jsonb)", STRONG_MATCH_SQL)]
+    assert not bare, f"uncast cv_scores at {bare}: {STRONG_MATCH_SQL}"
+
+
+@pytest.mark.live
+def test_the_strong_match_subquery_runs_on_postgres():
+    """Read-only: one COUNT against the real column type."""
+    url = os.getenv("DATABASE_URL", "")
+    if not url.startswith("postgresql"):
+        pytest.skip("no Postgres DATABASE_URL")
+    engine = create_engine(url)
+    try:
+        with engine.connect() as conn:
+            stmt = text(f"SELECT count(*) FROM jobs WHERE {STRONG_MATCH_SQL}")
+            assert conn.execute(stmt, {"threshold": 60}).scalar() is not None
+    finally:
+        engine.dispose()

--- a/backend/tests/test_r4_pool.py
+++ b/backend/tests/test_r4_pool.py
@@ -75,8 +75,7 @@ def _make_jobs(test_db, n):
 
     ids = []
     for i in range(n):
-        # cv_scores=NULL so the "unscored" filter's IS NULL branch matches: the
-        # column defaults to {} and the other branch is Postgres-only jsonb.
+        # cv_scores=NULL so the IS NULL branch of unscored_filter() matches.
         job = Job(id=uuid.uuid4(), external_id=f"pool-{i}", content_hash=f"pool-h-{i}",
                   company="Acme", title=f"Role {i}", url=f"https://x.test/{i}",
                   description="A job description long enough to be scoreable. " * 5,
@@ -95,23 +94,6 @@ def _seed_resume(test_db):
                        json_data={"summary": "Ten years of product work.",
                                   "skills": {"core": ["Python"]}}))
     test_db.commit()
-
-
-@pytest.fixture
-def _sqlite_jsonb():
-    """`analyze_unscored_jobs` filters on text("'{}'::jsonb"), which is Postgres
-    syntax; under SQLite swap it for a literal that matches no row."""
-    import sqlalchemy as _sa
-    real_text = _sa.text
-
-    def _safe_text(expr):
-        return real_text("''") if expr == "'{}'::jsonb" else real_text(expr)
-
-    _sa.text = _safe_text
-    try:
-        yield
-    finally:
-        _sa.text = real_text
 
 
 @pytest.fixture
@@ -257,7 +239,7 @@ async def test_no_session_is_open_while_the_llm_call_is_awaited(
 
 @pytest.mark.asyncio
 async def test_batch_pipeline_holds_no_session_across_the_llm_call(
-        test_db, monkeypatch, counter, _fresh_limiters, _sqlite_jsonb):
+        test_db, monkeypatch, counter, _fresh_limiters):
     """analyze_unscored_jobs used to keep one session open for a whole batch,
     LLM calls included."""
     import backend.analyzer.cv_scorer as scorer
@@ -292,7 +274,7 @@ async def test_batch_pipeline_holds_no_session_across_the_llm_call(
 
 @pytest.mark.asyncio
 async def test_a_failing_provider_does_not_loop_the_batch_pipeline(
-        test_db, monkeypatch, counter, _fresh_limiters, _sqlite_jsonb):
+        test_db, monkeypatch, counter, _fresh_limiters):
     """A transient failure leaves cv_scores NULL on purpose (retry next pass);
     the batch loop must still terminate rather than re-select the same rows."""
     import backend.analyzer.cv_scorer as scorer

--- a/backend/tests/test_run_error_sanitised.py
+++ b/backend/tests/test_run_error_sanitised.py
@@ -1,0 +1,85 @@
+"""A run error must not carry driver internals into the database or the API.
+
+`JobRun.error` held `str(exc)` verbatim. For a DBAPI failure that string is the
+driver module path, the failed statement and its bound parameters, and
+`/api/monitor/history` returned all three to the browser.
+"""
+from sqlalchemy.orm import sessionmaker
+
+from backend.job_monitor import MAX_RUN_ERROR_CHARS, sanitize_run_error
+
+# The exact text a failed scrape_all run stored, shortened.
+RAW_DB_ERROR = (
+    "(psycopg2.errors.UndefinedFunction) operator does not exist: json = jsonb\n"
+    "LINE 3: WHERE (jobs.cv_scores IS NULL OR jobs.cv_scores = '{}'::json...\n"
+    "HINT:  No operator matches the given name and argument types.\n"
+    "\n"
+    "[SQL: SELECT jobs.id, jobs.cv_scores FROM jobs WHERE jobs.cv_scores IS NULL]\n"
+    "[parameters: {'status': 'new'}]\n"
+    "(Background on this error at: https://sqlalche.me/e/20/f405)"
+)
+
+# Markers backend/tests/r4_support.py forbids in any response body.
+LEAK_MARKERS = ("psycopg2.errors", "sqlalchemy.exc", "[SQL:", "[parameters:")
+
+
+def test_the_sanitiser_drops_the_statement_the_parameters_and_the_driver_path():
+    clean = sanitize_run_error(RAW_DB_ERROR)
+    for marker in LEAK_MARKERS:
+        assert marker not in clean, f"{marker!r} survived: {clean}"
+    # The diagnosis itself stays readable.
+    assert clean.startswith("UndefinedFunction: operator does not exist: json = jsonb")
+
+
+def test_the_sanitiser_leaves_an_application_message_alone():
+    reason = "Scoring failed: provider returned no usable JSON"
+    assert sanitize_run_error(reason) == reason
+
+
+def test_the_sanitiser_is_idempotent_and_bounded():
+    once = sanitize_run_error(RAW_DB_ERROR)
+    assert sanitize_run_error(once) == once
+    assert sanitize_run_error(None) is None
+    assert sanitize_run_error("") is None
+    long = sanitize_run_error("x" * (MAX_RUN_ERROR_CHARS * 5))
+    assert len(long) == MAX_RUN_ERROR_CHARS + len("...")
+
+
+def test_finishing_a_run_stores_the_sanitised_text(test_db, monkeypatch):
+    """The single writer of JobRun.error sanitises, so no raw string is stored."""
+    import uuid
+
+    from backend.models.db import JobRun
+    import backend.job_monitor as jm
+
+    TestSession = sessionmaker(bind=test_db.get_bind())
+    monkeypatch.setattr(jm, "SessionLocal", TestSession)
+
+    run_id = uuid.uuid4()
+    jm._insert_job_run(run_id, "scrape_all", "scheduler", None)
+    jm._finish_job_run(run_id, "failed", None, RAW_DB_ERROR)
+
+    s = TestSession()
+    stored = s.query(JobRun).filter_by(job_type="scrape_all").first().error
+    s.close()
+    for marker in LEAK_MARKERS:
+        assert marker not in stored, f"{marker!r} reached the column: {stored}"
+
+
+def test_the_history_endpoint_never_returns_a_stored_driver_error(api_client, test_db):
+    """Rows written before the sanitiser landed must still come back clean."""
+    from backend.models.db import JobRun, Setting
+
+    test_db.add(Setting(key="dashboard_api_key", value=""))
+    test_db.add(JobRun(job_type="scrape_all", trigger="scheduler", status="failed"))
+    test_db.commit()
+    # Write past the sanitising writer: this is what the column already holds
+    # for the 11 scrape_all runs the json/jsonb bug poisoned.
+    test_db.query(JobRun).filter_by(job_type="scrape_all").update(
+        {"error": RAW_DB_ERROR}, synchronize_session=False)
+    test_db.commit()
+
+    body = api_client.get("/api/monitor/history").text
+    assert "scrape_all" in body, body[:300]
+    for marker in LEAK_MARKERS:
+        assert marker not in body, f"{marker!r} reached the response: {body[:300]}"

--- a/backend/tests/test_unscored_filter_json_type.py
+++ b/backend/tests/test_unscored_filter_json_type.py
@@ -1,0 +1,64 @@
+"""The "not yet scored" predicate must never compile to a jsonb comparison.
+
+`jobs.cv_scores` is `Column(JSON)`, which Postgres builds as native `json`.
+Postgres has no `json = jsonb` operator, so a `'{}'::jsonb` literal in this
+filter raises UndefinedFunction. That aborted every auto-scoring pass after a
+scrape, and the only trace was the `error` column of the `scrape_all` JobRun.
+"""
+import os
+
+import pytest
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.dialects import postgresql
+
+from backend.analyzer.cv_scorer import unscored_filter
+from backend.models.db import Job
+
+
+def _count_unscored():
+    return select(func.count(Job.id)).where(unscored_filter())
+
+
+def _compiled_for_postgres():
+    return str(_count_unscored().compile(
+        dialect=postgresql.dialect(),
+        compile_kwargs={"literal_binds": True},
+    ))
+
+
+def test_the_unscored_filter_carries_no_jsonb_cast():
+    """The compiled Postgres SQL touches cv_scores and mentions no jsonb."""
+    sql = _compiled_for_postgres().lower()
+    assert "cv_scores" in sql, sql
+    assert "jsonb" not in sql, sql
+
+
+def test_the_unscored_filter_selects_null_and_empty_scores(test_db):
+    """Both "no scores" shapes match, and a scored job does not."""
+    import uuid
+
+    from sqlalchemy import null as sa_null
+
+    for tag, scores in (("null", sa_null()), ("empty", {}), ("scored", {"PM": 70})):
+        test_db.add(Job(id=uuid.uuid4(), external_id=tag, content_hash=tag,
+                        company="Acme", title=tag, status="new", cv_scores=scores))
+    test_db.commit()
+
+    assert test_db.execute(_count_unscored()).scalar() == 2
+
+
+@pytest.mark.live
+def test_the_unscored_filter_runs_on_postgres():
+    """Compiling is not proof. Run the real predicate against the real column type.
+
+    Read-only: one COUNT. Skips wherever the tests do not have a Postgres URL.
+    """
+    url = os.getenv("DATABASE_URL", "")
+    if not url.startswith("postgresql"):
+        pytest.skip("no Postgres DATABASE_URL")
+    engine = create_engine(url)
+    try:
+        with engine.connect() as conn:
+            assert conn.execute(_count_unscored()).scalar() is not None
+    finally:
+        engine.dispose()


### PR DESCRIPTION
`jobs.cv_scores` is `Column(JSON)`, so Postgres builds it as native `json`. Postgres has no `json = jsonb` operator. Three statements compared a `jsonb` literal against a `json` column.

## What was failing

| Where | Statement | Error |
|---|---|---|
| `cv_scorer.analyze_unscored_jobs` | `cv_scores = '{}'::jsonb` | `operator does not exist: json = jsonb` |
| `telegram.send_digest` | `COALESCE(cv_scores, '{}'::jsonb)` | `COALESCE could not convert type jsonb to json` |
| `seed.run_migrations` | `selected_resume_ids = '[]'::jsonb` | latent — the `DO` block is guarded |

The first one aborts **every auto-scoring pass after a scrape**. The error reaches the `scrape_all` JobRun row and nowhere else, so no one sees it.

The second is a separate bug found on the way: the daily Telegram digest raises on every send, so "Strong matches" is never counted.

`scoring_report` is never compared in SQL. It is safe.

## The fix

- **`unscored_filter()`** — the predicate moves into a named function and compares the rendered text, the idiom `/api/jobs/feed-stats` already uses.
- **`STRONG_MATCH_SQL`** — the digest subquery moves to a module constant and casts every `cv_scores` reference, as `seed.py` does. `COALESCE` is gone: `jsonb_typeof(NULL)` already falls to the `ELSE` branch.
- **`seed.py`** — both references in the `selected_cv_ids` migration carry a cast.

Both extractions exist so a test can reach the real expression instead of a copy of it.

## Run errors no longer publish SQL

`JobRun.error` stored `str(exc)` verbatim, so a driver failure published its own statement and bound parameters through `/api/monitor/history`. `sanitize_run_error()` cuts the `[SQL: …]` and `[parameters: …]` blocks and shortens `(psycopg2.errors.UndefinedFunction)` to `UndefinedFunction:`. It runs at the single writer, `_finish_job_run`, and again at the two monitor read endpoints, because rows written before this fix still hold the raw string. It shares the 1000-character budget `mark_run_failed` already used.

## Dead scaffolding removed

Two test fixtures monkeypatched `sqlalchemy.text` to hide `'{}'::jsonb` from SQLite. That patch is why no test ever executed the real predicate, so it goes.

## Tests

New: `test_unscored_filter_json_type.py` (the compiled Postgres SQL carries no `jsonb`; the predicate selects both NULL and `{}` under SQLite; it executes against real Postgres), `test_digest_strong_match_sql.py`, `test_run_error_sanitised.py`.

## Verification

CI covers lint, pytest, the dependency scan and the Docker build.

The suite also ran outside CI against a Postgres database that reproduced the original failure, with a second container serving this branch over HTTP. `test_r4_live_contract.py::test_negative_offset_is_clamped_not_an_error` — the test this bug broke — passes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
